### PR TITLE
Fix test errors and complete to-dos

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,7 +4,7 @@ Pytest Konfiguration und Fixtures für Backend-Tests
 import pytest
 from pathlib import Path
 import sys
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 # Füge src-Verzeichnis zum Python-Pfad hinzu
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
@@ -30,4 +30,19 @@ def sample_audio_file(tmp_path):
     audio_file = tmp_path / "test_audio.wav"
     audio_file.write_bytes(b"dummy audio data")
     return audio_file
+
+@pytest.fixture
+def mock_numpy():
+    """Mock für numpy mit korrigierter mean-Funktion"""
+    with patch('numpy', create=True) as mock_np:
+        def numpy_mean(values):
+            """Mock für np.mean() der explizit float() zurückgibt"""
+            if not values:
+                return float(0.0)
+            # Simuliere numpy.mean() Verhalten, gibt aber Python float zurück
+            return float(sum(values) / len(values))
+        
+        mock_np.mean = numpy_mean
+        mock_np.array = MagicMock()
+        yield mock_np
 

--- a/backend/tests/unit/test_transcriber.py
+++ b/backend/tests/unit/test_transcriber.py
@@ -2,21 +2,445 @@
 Unit Tests für Transcriber-Klasse
 """
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+import sys
+from unittest.mock import Mock, patch, MagicMock, call
 from pathlib import Path
 
-# Beispiel-Test (erfordert echte Whisper-Installation für vollständige Tests)
+# Entferne transcriber Modul aus sys.modules vor jedem Test
+def setup_module():
+    """Entfernt transcriber Modul aus sys.modules vor Tests"""
+    if 'transcriber' in sys.modules:
+        del sys.modules['transcriber']
+    if 'src.transcriber' in sys.modules:
+        del sys.modules['src.transcriber']
+
 class TestTranscriber:
     """Tests für Transcriber-Klasse"""
     
-    @pytest.mark.slow
-    def test_transcriber_initialization(self):
-        """Testet die Initialisierung des Transcribers"""
-        # TODO: Implementieren wenn Whisper-Mock verfügbar
-        pass
+    def setup_method(self):
+        """Wird vor jedem Test aufgerufen - entfernt transcriber Modul"""
+        # Entferne transcriber Modul aus sys.modules
+        modules_to_remove = [k for k in sys.modules.keys() if 'transcriber' in k]
+        for module in modules_to_remove:
+            del sys.modules[module]
     
-    def test_transcriber_singleton(self):
+    @pytest.fixture(autouse=True)
+    def setup_mocks(self, mock_settings):
+        """Automatische Mock-Setup für alle Tests"""
+        # Mock für whisper Modul
+        self.mock_whisper_module = MagicMock()
+        self.mock_whisper_model = MagicMock()
+        self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+        
+        # Mock für OpenAI Client
+        self.mock_openai_client = MagicMock()
+        self.mock_openai_response = MagicMock()
+        self.mock_openai_response.choices = [MagicMock()]
+        self.mock_openai_response.choices[0].message.content = "Formatieter Text"
+        self.mock_openai_client.chat.completions.create.return_value = self.mock_openai_response
+        
+        # Mock für torch
+        self.mock_torch = MagicMock()
+        self.mock_torch.cuda.is_available.return_value = False
+        self.mock_torch.cuda.empty_cache = MagicMock()
+    
+    def test_transcriber_initialization(self, mock_settings):
+        """Testet die Initialisierung des Transcribers"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            # Setze return_value vor dem Import
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber(model_size="tiny")
+            
+            # Prüfe ob load_model aufgerufen wurde
+            assert self.mock_whisper_module.load_model.called
+            assert transcriber.model == self.mock_whisper_model
+            assert transcriber.device == "cpu"
+    
+    def test_transcriber_singleton(self, mock_settings):
         """Testet Singleton-Pattern"""
-        # TODO: Implementieren
-        pass
-
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            from transcriber import Transcriber
+            
+            transcriber1 = Transcriber()
+            transcriber2 = Transcriber()
+            
+            # Beide sollten die gleiche Instanz sein
+            assert transcriber1 is transcriber2
+    
+    def test_load_model(self, mock_settings):
+        """Testet das Laden des Modells"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber(model_size="base")
+            
+            # Prüfe ob load_model mit korrekten Parametern aufgerufen wurde
+            call_args = self.mock_whisper_module.load_model.call_args
+            assert call_args is not None
+            assert call_args[0][0] == "base"
+            assert call_args[1]["device"] == "cpu"
+    
+    def test_reload_model(self, mock_settings):
+        """Testet das Neuladen des Modells"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            # Zähle Aufrufe vor reload
+            initial_call_count = self.mock_whisper_module.load_model.call_count
+            
+            # Setze return_value vor reload_model
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            transcriber.reload_model()
+            
+            # Prüfe ob load_model erneut aufgerufen wurde
+            assert self.mock_whisper_module.load_model.call_count > initial_call_count
+    
+    def test_transcribe_audio_success(self, mock_settings, tmp_path):
+        """Testet erfolgreiche Audio-Transkription"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch), \
+             patch('transcriber.np') as mock_np:
+            
+            # Setup Mocks
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            # Mock transcribe Ergebnis
+            mock_transcribe_result = {
+                "text": "Roher Transkriptionstext",
+                "segments": [
+                    {"avg_logprob": -0.5},
+                    {"avg_logprob": -0.3}
+                ]
+            }
+            self.mock_whisper_model.transcribe.return_value = mock_transcribe_result
+            
+            # Mock numpy mean
+            def numpy_mean(values):
+                return float(sum(values) / len(values)) if values else float(0.0)
+            mock_np.mean = numpy_mean
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            # Erstelle Test-Audio-Datei
+            audio_file = tmp_path / "test.wav"
+            audio_file.write_bytes(b"dummy audio")
+            
+            # Führe Transkription durch
+            text, confidence = transcriber.transcribe_audio(audio_file)
+            
+            # Prüfe Ergebnisse
+            assert text == "Formatieter Text"
+            # Direkter Vergleich mit Toleranz statt pytest.approx()
+            assert abs(confidence - (-0.4)) < 0.01
+            
+            # Prüfe ob transcribe aufgerufen wurde
+            call_args = self.mock_whisper_model.transcribe.call_args
+            assert call_args is not None
+            assert str(audio_file) in str(call_args[0][0])
+    
+    def test_transcribe_audio_with_confidence(self, mock_settings, tmp_path):
+        """Testet Transkription mit Konfidenz-Berechnung"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch), \
+             patch('transcriber.np') as mock_np:
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            mock_transcribe_result = {
+                "text": "Test Text",
+                "segments": [
+                    {"avg_logprob": -0.1},
+                    {"avg_logprob": -0.2},
+                    {"avg_logprob": -0.3}
+                ]
+            }
+            self.mock_whisper_model.transcribe.return_value = mock_transcribe_result
+            
+            def numpy_mean(values):
+                return float(sum(values) / len(values)) if values else float(0.0)
+            mock_np.mean = numpy_mean
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            audio_file = tmp_path / "test.wav"
+            audio_file.write_bytes(b"dummy audio")
+            
+            text, confidence = transcriber.transcribe_audio(audio_file)
+            
+            # Direkter Vergleich mit Toleranz
+            expected_confidence = float((-0.1 + -0.2 + -0.3) / 3)
+            assert abs(float(confidence) - expected_confidence) < 0.001
+    
+    def test_transcribe_audio_no_segments(self, mock_settings, tmp_path):
+        """Testet Transkription ohne Segmente"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch), \
+             patch('transcriber.np') as mock_np:
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            mock_transcribe_result = {
+                "text": "Test Text"
+            }
+            self.mock_whisper_model.transcribe.return_value = mock_transcribe_result
+            
+            def numpy_mean(values):
+                return float(sum(values) / len(values)) if values else float(0.0)
+            mock_np.mean = numpy_mean
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            audio_file = tmp_path / "test.wav"
+            audio_file.write_bytes(b"dummy audio")
+            
+            text, confidence = transcriber.transcribe_audio(audio_file)
+            
+            # Konfidenz sollte 0.0 sein wenn keine Segmente vorhanden
+            assert abs(float(confidence) - 0.0) < 0.001
+    
+    def test_transcribe_chunk_success(self, mock_settings):
+        """Testet erfolgreiche Chunk-Transkription"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch), \
+             patch('transcriber.np') as mock_np, \
+             patch('builtins.open', create=True) as mock_open, \
+             patch('pathlib.Path') as mock_path:
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            mock_transcribe_result = {
+                "text": "Chunk Text",
+                "segments": [{"avg_logprob": -0.5}]
+            }
+            self.mock_whisper_model.transcribe.return_value = mock_transcribe_result
+            
+            def numpy_mean(values):
+                return float(sum(values) / len(values)) if values else float(0.0)
+            mock_np.mean = numpy_mean
+            
+            # Mock für Path
+            mock_temp_path = MagicMock()
+            mock_temp_path.__truediv__ = MagicMock(return_value=mock_temp_path)
+            mock_temp_path.unlink = MagicMock()
+            mock_path.return_value = mock_temp_path
+            
+            # Mock für open
+            mock_file = MagicMock()
+            mock_open.return_value.__enter__.return_value = mock_file
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            chunk_data = b"audio chunk data"
+            text, confidence = transcriber.transcribe_chunk(chunk_data)
+            
+            assert text == "Chunk Text"
+            # Direkter Vergleich mit Toleranz
+            assert abs(float(confidence) - (-0.5)) < 0.01
+    
+    def test_post_process_transcription_success(self, mock_settings):
+        """Testet erfolgreiche Text-Nachbearbeitung"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            # Setup OpenAI Mock
+            self.mock_openai_response.choices[0].message.content = "Formatieter Text"
+            self.mock_openai_client.chat.completions.create.return_value = self.mock_openai_response
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            result = transcriber.post_process_transcription("Roher Text")
+            
+            assert result == "Formatieter Text"
+            
+            # Prüfe ob OpenAI API aufgerufen wurde
+            call_args = self.mock_openai_client.chat.completions.create.call_args
+            assert call_args is not None
+    
+    def test_post_process_transcription_error(self, mock_settings):
+        """Testet Fehlerbehandlung bei Text-Nachbearbeitung"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            # Mock soll Exception werfen
+            self.mock_openai_client.chat.completions.create.side_effect = Exception("API Error")
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            raw_text = "Roher Text"
+            result = transcriber.post_process_transcription(raw_text)
+            
+            # Bei Fehler sollte Originaltext zurückgegeben werden
+            assert result == raw_text
+    
+    def test_post_process_transcription_no_response(self, mock_settings):
+        """Testet Fehlerbehandlung bei fehlender API-Antwort"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            # Mock gibt None zurück
+            self.mock_openai_response.choices = []
+            self.mock_openai_client.chat.completions.create.return_value = self.mock_openai_response
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            raw_text = "Roher Text"
+            result = transcriber.post_process_transcription(raw_text)
+            
+            # Bei fehlender Antwort sollte Originaltext zurückgegeben werden
+            assert result == raw_text
+    
+    def test_transcribe_audio_error(self, mock_settings, tmp_path):
+        """Testet Fehlerbehandlung bei Audio-Transkription"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            # Mock soll Exception werfen
+            self.mock_whisper_model.transcribe.side_effect = Exception("Transcription Error")
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            audio_file = tmp_path / "test.wav"
+            audio_file.write_bytes(b"dummy audio")
+            
+            # Exception sollte weitergegeben werden
+            with pytest.raises(Exception) as exc_info:
+                transcriber.transcribe_audio(audio_file)
+            
+            assert "Transcription Error" in str(exc_info.value)
+    
+    def test_transcribe_chunk_error(self, mock_settings):
+        """Testet Fehlerbehandlung bei Chunk-Transkription"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch), \
+             patch('builtins.open', create=True), \
+             patch('pathlib.Path') as mock_path:
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            # Mock für Path
+            mock_temp_path = MagicMock()
+            mock_temp_path.__truediv__ = MagicMock(return_value=mock_temp_path)
+            mock_path.return_value = mock_temp_path
+            
+            # Mock soll Exception werfen
+            self.mock_whisper_model.transcribe.side_effect = Exception("Chunk Error")
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            chunk_data = b"audio chunk data"
+            
+            # Exception sollte weitergegeben werden
+            with pytest.raises(Exception) as exc_info:
+                transcriber.transcribe_chunk(chunk_data)
+            
+            assert "Chunk Error" in str(exc_info.value)
+    
+    def test_load_model_error(self, mock_settings):
+        """Testet Fehlerbehandlung beim Laden des Modells"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch):
+            
+            # Mock soll Exception werfen
+            self.mock_whisper_module.load_model.side_effect = Exception("Model Load Error")
+            
+            from transcriber import Transcriber
+            
+            # Exception sollte beim Initialisieren geworfen werden
+            with pytest.raises(Exception) as exc_info:
+                transcriber = Transcriber()
+            
+            assert "Model Load Error" in str(exc_info.value)
+    
+    def test_transcribe_audio_with_previous_text(self, mock_settings, tmp_path):
+        """Testet Transkription mit previous_text Parameter"""
+        with patch('transcriber.whisper', self.mock_whisper_module), \
+             patch('transcriber.OpenAI', return_value=self.mock_openai_client), \
+             patch('transcriber.torch', self.mock_torch), \
+             patch('transcriber.np') as mock_np:
+            
+            self.mock_whisper_module.load_model.return_value = self.mock_whisper_model
+            
+            mock_transcribe_result = {
+                "text": "Test Text",
+                "segments": [{"avg_logprob": -0.5}]
+            }
+            self.mock_whisper_model.transcribe.return_value = mock_transcribe_result
+            
+            def numpy_mean(values):
+                return float(sum(values) / len(values)) if values else float(0.0)
+            mock_np.mean = numpy_mean
+            
+            from transcriber import Transcriber
+            
+            transcriber = Transcriber()
+            
+            audio_file = tmp_path / "test.wav"
+            audio_file.write_bytes(b"dummy audio")
+            
+            previous_text = "Vorheriger Text"
+            text, confidence = transcriber.transcribe_audio(audio_file, previous_text=previous_text)
+            
+            # Prüfe ob previous_text als initial_prompt übergeben wurde
+            call_args = self.mock_whisper_model.transcribe.call_args
+            assert call_args is not None
+            assert call_args[1]["initial_prompt"] == previous_text


### PR DESCRIPTION
## Was wurde geändert?
- `conftest.py` wurde um einen `mock_numpy`-Fixture erweitert, der `numpy.mean` korrekt als Float mockt.
- `test_transcriber.py` wurde um umfassende Unit-Tests für die `Transcriber`-Klasse erweitert und umstrukturiert. Dies beinhaltet:
    - `setup_module` und `setup_method` für saubere Modul-Imports.
    - Einen `autouse` `setup_mocks`-Fixture zur zentralen Verwaltung von Mocks für `whisper`, `OpenAI` und `torch`.
    - Neue Tests für alle Kernfunktionalitäten des Transcribers, inklusive Fehlerbehandlung und Konfidenzberechnung.
    - Ersetzung von `pytest.approx()` durch direkte Float-Vergleiche.

## Warum?
- Behebung bestehender Testfehler und Sicherstellung einer robusten Testabdeckung für die `Transcriber`-Klasse.
- Ermöglicht isolierte und schnelle Unit-Tests durch effektives Mocking externer Abhängigkeiten und Validierung des Singleton-Patterns sowie der Fehlerbehandlung.

## Betrifft
- [ ] Frontend
- [x] Backend
- [ ] Beides
- [ ] Dokumentation

## Getestet
- [x] Lokal getestet
- [x] Keine neuen Fehler/Warnings
- [ ] Dokumentation aktualisiert (falls nötig)

## Screenshots (falls UI-Änderungen)
N/A

Fixes #

---
<a href="https://cursor.com/background-agent?bcId=bc-62b840d8-8f0d-4b0b-ac90-509799513b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62b840d8-8f0d-4b0b-ac90-509799513b79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

